### PR TITLE
Fix NameError in python3 code

### DIFF
--- a/mockthink/ast.py
+++ b/mockthink/ast.py
@@ -9,6 +9,7 @@ import dateutil.parser
 from pprint import pprint
 from future.utils import iteritems, text_type
 from past.utils import old_div
+from past.builtins import basestring
 
 from . import util, joins, rtime
 from .scope import Scope

--- a/mockthink/version.py
+++ b/mockthink/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.9.6'
+VERSION = '0.9.7'


### PR DESCRIPTION
Seems like the `ISO8601` MonExp isn't well tested, not sure the best way to handle it.