### PR TITLE
Update to support rethinkdb-python 2.4.8

### DIFF
--- a/mockthink/ast.py
+++ b/mockthink/ast.py
@@ -1,5 +1,3 @@
-
-
 from rethinkdb.errors import RqlRuntimeError, RqlDriverError, RqlCompileError
 import operator
 import random
@@ -9,7 +7,6 @@ import dateutil.parser
 from pprint import pprint
 from future.utils import iteritems, text_type
 from past.utils import old_div
-from past.builtins import str
 
 from . import util, joins, rtime
 from .scope import Scope
@@ -17,7 +14,6 @@ from .scope import Scope
 from . import ast_base
 from .ast_base import RBase, MonExp, BinExp, Ternary, ByFuncBase
 from .ast_base import LITERAL_OBJECT, LITERAL_LIST, RDatum, RFunc, MakeObj, MakeArray
-from past.builtins import filter
 
 
 # #################

--- a/mockthink/ast.py
+++ b/mockthink/ast.py
@@ -759,6 +759,11 @@ class IndexCreateByFunc(RBase):
         )
 
 
+class Wait(MonExp):
+    def do_run(self, table_or_seq, arg, scope):
+        pass
+
+
 class IndexRename(Ternary):
     def do_run(self, sequence, old_name, new_name, arg, scope):
         current_db = self.find_db_scope()

--- a/mockthink/db.py
+++ b/mockthink/db.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import contextlib
 from pprint import pprint
 
@@ -11,6 +9,7 @@ from .rql_rewrite import rewrite_query
 from .scope import Scope
 from past.builtins import xrange
 
+
 def fill_missing_report_results(report):
     defaults = {
         'errors': 0,
@@ -21,13 +20,14 @@ def fill_missing_report_results(report):
     }
     return util.extend(defaults, report)
 
+
 def replace_array_elems_by_id(existing, replace_with):
     report = {
         'replaced': 0,
         'changes': []
     }
     elem_index_by_id = {}
-    for index in xrange(0, len(existing)):
+    for index in range(0, len(existing)):
         elem = existing[index]
         elem_index_by_id[util.getter('id')(elem)] = index
 
@@ -45,6 +45,7 @@ def replace_array_elems_by_id(existing, replace_with):
 
     return to_return, fill_missing_report_results(report)
 
+
 def remove_array_elems_by_id(existing, to_remove):
     report = {
         'deleted': 0,
@@ -57,6 +58,7 @@ def remove_array_elems_by_id(existing, to_remove):
             report['changes'].append({'old_val': elem, 'new_val': None})
             result.remove(elem)
     return result, report
+
 
 def insert_into_table_with_conflict_setting(existing, to_insert, conflict):
     assert(conflict in ('error', 'update', 'replace'))
@@ -94,6 +96,7 @@ def insert_into_table_with_conflict_setting(existing, to_insert, conflict):
     not_updated = [row for row in existing if row['id'] not in seen]
     result = not_updated + result
     return result, fill_missing_report_results(result_report)
+
 
 class MockTableData(object):
     def __init__(self, name, rows, indexes):
@@ -143,7 +146,7 @@ class MockTableData(object):
         return MockTableData(self.name, self.rows, new_indexes)
 
     def list_indexes(self):
-        return self.indexes.keys()
+        return list(self.indexes.keys())
 
     def index_exists(self, index):
         return index in self.indexes
@@ -168,7 +171,8 @@ class MockTableData(object):
         return self.rows[index]
 
     def __repr__(self):
-        return '<MockTableData name="%s"/>' % self.name
+        return f'<MockTableData name="{self.name}"/>'
+
 
 class MockDbData(object):
     def __init__(self, tables_by_name):
@@ -178,7 +182,7 @@ class MockDbData(object):
         return self.set_table(table_name, MockTableData(table_name, [], {}))
 
     def list_tables(self):
-        return self.tables_by_name.keys()
+        return list(self.tables_by_name.keys())
 
     def drop_table(self, table_name):
         return MockDbData(util.without([table_name], self.tables_by_name))
@@ -191,6 +195,7 @@ class MockDbData(object):
         tables = util.obj_clone(self.tables_by_name)
         tables[table_name] = new_table_instance
         return MockDbData(tables)
+
 
 class MockDb(object):
     def __init__(self, dbs_by_name):
@@ -225,7 +230,7 @@ class MockDb(object):
         return MockDb(util.without([db_name], self.dbs_by_name))
 
     def list_dbs(self):
-        return self.dbs_by_name.keys()
+        return list(self.dbs_by_name.keys())
 
     def replace_table_in_db(self, db_name, table_name, table_data_instance):
         assert(isinstance(table_data_instance, MockTableData))
@@ -279,6 +284,7 @@ class MockDb(object):
     def get_now_time(self):
         return self.mockthink.get_now_time()
 
+
 def objects_from_pods(data):
     dbs_by_name = {}
     for db_name, db_data in iteritems(data['dbs']):
@@ -295,18 +301,22 @@ def objects_from_pods(data):
         dbs_by_name[db_name] = MockDbData(tables_by_name)
     return MockDb(dbs_by_name)
 
+
 class MockThinkConn(object):
     def __init__(self, mockthink_parent):
         self.mockthink_parent = mockthink_parent
+
     def reset_data(self, data):
         self.mockthink_parent._modify_initial_data(data)
+
     def _start(self, rql_query, **global_optargs):
         return self.mockthink_parent.run_query(rewrite_query(rql_query))
+
 
 class MockThink(object):
     def __init__(self, initial_data):
         self._modify_initial_data(initial_data)
-        self.tzinfo = rethinkdb.make_timezone('00:00')
+        self.tzinfo = rethinkdb.r.make_timezone('00:00')
 
     def _modify_initial_data(self, new_data):
         self.initial_data = new_data
@@ -340,7 +350,7 @@ class MockThink(object):
         return result
 
     def pprint_query_ast(self, query):
-        query = "%s" % query
+        query = f"{query}"
         print(query)
 
     def reset(self):

--- a/mockthink/db.py
+++ b/mockthink/db.py
@@ -7,7 +7,6 @@ from future.utils import iteritems
 from . import rtime, util
 from .rql_rewrite import rewrite_query
 from .scope import Scope
-from past.builtins import xrange
 
 
 def fill_missing_report_results(report):
@@ -311,6 +310,9 @@ class MockThinkConn(object):
 
     def _start(self, rql_query, **global_optargs):
         return self.mockthink_parent.run_query(rewrite_query(rql_query))
+
+    def is_open(self):
+        return True
 
 
 class MockThink(object):

--- a/mockthink/joins.py
+++ b/mockthink/joins.py
@@ -1,6 +1,7 @@
 from pprint import pprint
 from . import util
 
+
 def do_outer_join(pred, left, right):
     out = []
     for left_elem in left:
@@ -14,6 +15,7 @@ def do_outer_join(pred, left, right):
         out = util.cat(out, matches)
     return out
 
+
 def do_inner_join(pred, left, right):
     out = []
     for left_elem in left:
@@ -21,6 +23,7 @@ def do_inner_join(pred, left, right):
             if pred(left_elem, right_elem):
                 out.append({'left': left_elem, 'right': right_elem})
     return out
+
 
 def do_eq_join(left_field, left, right_field, right):
     out = []

--- a/mockthink/rql_rewrite.py
+++ b/mockthink/rql_rewrite.py
@@ -403,6 +403,8 @@ def handle_order_by(node):
             accepted = (r_ast.Desc, r_ast.Asc, r_ast.Func)
             assert(elem.__class__ in accepted)
             right.append(type_dispatch(elem))
+    if optargs.get("index"):
+        right.append(mt_ast.Asc(type_dispatch(r_ast.Datum(optargs["index"]))))
     if isinstance(right[0], mt_ast.RFunc):
         right = right[0]
         return mt_ast.OrderByFunc(left, right, optargs=optargs)

--- a/mockthink/rql_rewrite.py
+++ b/mockthink/rql_rewrite.py
@@ -219,7 +219,8 @@ NORMAL_BINOPS = {
     r_ast.TableCreate: mt_ast.TableCreate,
     r_ast.TableDrop: mt_ast.TableDrop,
     r_ast.Default: mt_ast.RDefault,
-    r_ast.CoerceTo: mt_ast.CoerceTo
+    r_ast.CoerceTo: mt_ast.CoerceTo,
+    r_ast.Limit: mt_ast.Limit
 }
 
 

--- a/mockthink/rql_rewrite.py
+++ b/mockthink/rql_rewrite.py
@@ -1,7 +1,6 @@
 import rethinkdb.ast as r_ast
 from future.utils import iteritems
 
-
 from . import ast as mt_ast
 from . import util
 
@@ -45,7 +44,6 @@ def handle_generic_monop(Mt_Constructor, node):
 
 @util.curry2
 def handle_generic_binop(Mt_Constructor, node):
-    #raise Exception(dir(node))
     return Mt_Constructor(
         type_dispatch(node._args[0]),
         type_dispatch(node._args[1]),
@@ -144,7 +142,7 @@ def binop_splat(Mt_Constructor, node):
 #   0-ary reql terms which don't need any special handling
 NORMAL_ZEROPS = {
     r_ast.Now: mt_ast.Now,
-    r_ast.DbList: mt_ast.DbList
+    r_ast.DbList: mt_ast.DbList,
 }
 
 
@@ -181,7 +179,8 @@ NORMAL_MONOPS = {
     r_ast.ToEpochTime: mt_ast.ToEpochTime,
     r_ast.Literal: mt_ast.Literal,
     r_ast.Distinct: mt_ast.Distinct,
-    r_ast.ISO8601: mt_ast.ISO8601
+    r_ast.ISO8601: mt_ast.ISO8601,
+    r_ast.Wait: mt_ast.Wait
 }
 
 #   2-ary reql terms which don't need any special handling

--- a/mockthink/rtime.py
+++ b/mockthink/rtime.py
@@ -2,34 +2,42 @@ import rethinkdb
 import datetime
 import time
 
+
 def to_date(dt, timezone=None):
     return datetime.datetime(dt.year, dt.month, dt.day, tzinfo=dt.tzinfo)
+
 
 def time_of_day_seconds(dt):
     minutes = (dt.hour * 60) + dt.minute
     return (minutes * 60) + dt.second
 
+
 def day_of_year(dt):
     raise NotImplementedError
 
+
 def make_time(year, month, day, hour=0, minute=0, second=0, timezone=None):
-    timezone = timezone or rethinkdb.make_timezone('00:00')
+    timezone = timezone or rethinkdb.r.make_timezone('00:00')
     return datetime.datetime(year, month, day, hour, minute, second, tzinfo=timezone)
+
 
 def now():
     dtime = datetime.datetime.now()
-    return dtime.replace(tzinfo=rethinkdb.make_timezone('00:00'))
+    return dtime.replace(tzinfo=rethinkdb.r.make_timezone('00:00'))
+
 
 def create_rql_timezone(timezone_string):
     if timezone_string == 'Z':
-        return rethinkdb.make_timezone('00:00')
+        return rethinkdb.r.make_timezone('00:00')
     else:
         raise NotImplementedError
+
 
 def epoch_time(dt):
     #   there's definitely a better way to do this.
     jan1_1970 = datetime.datetime(1970, 1, 1, tzinfo=dt.tzinfo)
     return int((dt - jan1_1970).total_seconds())
+
 
 def rql_compatible_time(year, month, day, *args):
     hour, minute, second = (0, 0, 0)

--- a/mockthink/scope.py
+++ b/mockthink/scope.py
@@ -1,8 +1,11 @@
-from __future__ import print_function
+
+
+
 class NotInScopeErr(Exception):
     def __init__(self, msg):
         print(msg)
         self.msg = msg
+
 
 class Scope(object):
     def __init__(self, values):
@@ -15,7 +18,7 @@ class Scope(object):
         elif hasattr(self, 'parent'):
             result = self.parent.get_sym(x)
         if result == None:
-            msg = "symbol not defined: %s" % x
+            msg = f"symbol not defined: {x}"
             raise NotInScopeErr(msg)
         return result
 
@@ -34,4 +37,3 @@ class Scope(object):
 
     def log(self):
         pprint(self.get_flattened())
-

--- a/mockthink/test/common.py
+++ b/mockthink/test/common.py
@@ -1,8 +1,8 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
+
 
 import unittest
 
-import rethinkdb as r
+from rethinkdb import r
 from future.utils import iteritems
 
 import mockthink.util as util
@@ -11,7 +11,7 @@ from mockthink.db import MockThinkConn
 
 def real_stock_data_load(data, connection):
     for db in list(r.db_list().run(connection)):
-        if db == u"rethinkdb":
+        if db == "rethinkdb":
             # This db is special and can't be deleted.
             continue
         r.db_drop(db).run(connection)

--- a/mockthink/test/conftest.py
+++ b/mockthink/test/conftest.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 import rethinkdb
 from pytest_server_fixtures.rethink import rethink_server, rethink_server_sess
@@ -34,7 +30,7 @@ def conn_sess(request):
     elif conn_type == "mockthink":
         conn = MockThink(as_db_and_table('nothing', 'nothing', [])).get_conn()
     else:
-        pytest.exit("Unknown mockthink test connection type: " + conn_type)
+        pytest.exit(f"Unknown mockthink test connection type: {conn_type}")
     return conn
 
 

--- a/mockthink/test/functional/common.py
+++ b/mockthink/test/functional/common.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 
 class MockTest(object):

--- a/mockthink/test/functional/test_aggregation.py
+++ b/mockthink/test/functional/test_aggregation.py
@@ -1,5 +1,5 @@
-import rethinkdb as r
-from rethinkdb import RqlRuntimeError
+from rethinkdb import r
+from rethinkdb.errors import RqlRuntimeError
 
 from mockthink import util
 from mockthink.test.common import as_db_and_table, assertEqual

--- a/mockthink/test/functional/test_array_manip.py
+++ b/mockthink/test/functional/test_array_manip.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 from pprint import pprint
@@ -164,9 +164,9 @@ class TestSample(MockTest):
     @staticmethod
     def get_data():
         data = [
-            {'id': 'one', 'data': range(10, 20)},
-            {'id': 'two', 'data': range(20, 30)},
-            {'id': 'three', 'data': range(30, 40)}
+            {'id': 'one', 'data': list(range(10, 20))},
+            {'id': 'two', 'data': list(range(20, 30))},
+            {'id': 'three', 'data': list(range(30, 40))}
         ]
         return as_db_and_table('db', 'things', data)
 

--- a/mockthink/test/functional/test_between.py
+++ b/mockthink/test/functional/test_between.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 

--- a/mockthink/test/functional/test_bracket_mapping.py
+++ b/mockthink/test/functional/test_bracket_mapping.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqual
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_contains.py
+++ b/mockthink/test/functional/test_contains.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqual
 from mockthink.test.functional.common import MockTest
 from mockthink.util import DictableSet

--- a/mockthink/test/functional/test_distinct.py
+++ b/mockthink/test/functional/test_distinct.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest
 from mockthink.util import DictableSet

--- a/mockthink/test/functional/test_grouping.py
+++ b/mockthink/test/functional/test_grouping.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqual, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_indexes.py
+++ b/mockthink/test/functional/test_indexes.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_joins.py
+++ b/mockthink/test/functional/test_joins.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 
 from mockthink.test.common import assertEqUnordered
 from mockthink.test.functional.common import MockTest

--- a/mockthink/test/functional/test_logic.py
+++ b/mockthink/test/functional/test_logic.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_math.py
+++ b/mockthink/test/functional/test_math.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_merge.py
+++ b/mockthink/test/functional/test_merge.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_misc.py
+++ b/mockthink/test/functional/test_misc.py
@@ -348,8 +348,6 @@ class TestObjectManip(MockTest):
             ['id', 'attributes', 'sam-attr']
         ]
 
-        #res = list(r.db('y').table('people').run(conn))
-        #raise Exception(repr(res[0].keys()))
         result = list(r.db('y').table('people').map(
             lambda d: d.keys()
         ).run(conn))
@@ -484,4 +482,3 @@ class TestError(MockTest):
             rql_err = err
             assertEqual('msg', err.message)
         assert(isinstance(rql_err, RqlRuntimeError))
-

--- a/mockthink/test/functional/test_misc.py
+++ b/mockthink/test/functional/test_misc.py
@@ -1,5 +1,5 @@
-import rethinkdb as r
-from rethinkdb import RqlRuntimeError
+from rethinkdb import r
+from rethinkdb.errors import RqlRuntimeError
 
 from mockthink import util
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
@@ -281,7 +281,7 @@ class TestSets(MockTest):
         result = r.db('z').table('t').map(
             lambda doc: doc['simple'].set_insert('y')
         ).run(conn)
-        result = map(lambda d: set(d), result)
+        result = [set(d) for d in result]
         assertEqUnordered(expected, result)
 
     def test_set_union(self, conn):
@@ -292,7 +292,7 @@ class TestSets(MockTest):
         result = r.db('z').table('t').map(
             lambda doc: doc['simple'].set_union(['y', 'a'])
         ).run(conn)
-        result = map(lambda d: set(d), result)
+        result = [set(d) for d in result]
         assertEqUnordered(expected, result)
 
     def test_set_intersection(self, conn):
@@ -303,7 +303,7 @@ class TestSets(MockTest):
         result = r.db('z').table('t').map(
             lambda doc: doc['simple'].set_intersection(['x', 'y'])
         ).run(conn)
-        result = map(lambda d: set(d), result)
+        result = [set(d) for d in result]
         assertEqUnordered(expected, result)
 
     def test_set_difference(self, conn):
@@ -315,7 +315,7 @@ class TestSets(MockTest):
             lambda doc: doc['simple'].set_difference(['y'])
         ).run(conn)
         result = list(result)
-        result = map(lambda d: set(d), result)
+        result = [set(d) for d in result]
         assertEqUnordered(expected, result)
 
 
@@ -347,9 +347,13 @@ class TestObjectManip(MockTest):
             ['id', 'attributes', 'joe-attr'],
             ['id', 'attributes', 'sam-attr']
         ]
+
+        #res = list(r.db('y').table('people').run(conn))
+        #raise Exception(repr(res[0].keys()))
         result = list(r.db('y').table('people').map(
             lambda d: d.keys()
         ).run(conn))
+
         assertEqual(3, len(result[0]))
         assertEqual(3, len(result[1]))
         key_set = set(util.cat(result[0], result[1]))

--- a/mockthink/test/functional/test_order_by.py
+++ b/mockthink/test/functional/test_order_by.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.functional.common import MockTest
 from mockthink.test.common import as_db_and_table, assertEqual
 

--- a/mockthink/test/functional/test_order_by.py
+++ b/mockthink/test/functional/test_order_by.py
@@ -68,6 +68,14 @@ class TestOrderByOne(MockTest):
         result = r.db('y').table('scores').order_by(r.desc('score')).run(conn)
         assertEqual(expected, list(result))
 
+    def test_sort_1_attr_2_asc_index(self, conn):
+        expected = [
+            {'id': 'todd', 'age': 52, 'score': 15},
+            {'id': 'joe', 'age': 26, 'score': 60},
+            {'id': 'bill', 'age': 35, 'score': 78},
+        ]
+        result = r.db('y').table('scores').order_by(index='score').run(conn)
+        assertEqual(expected, list(result))
 
 class TestOrderByMulti(MockTest):
     @staticmethod

--- a/mockthink/test/functional/test_pluck.py
+++ b/mockthink/test/functional/test_pluck.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/functional/test_strings.py
+++ b/mockthink/test/functional/test_strings.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest
 

--- a/mockthink/test/functional/test_table_db_mod.py
+++ b/mockthink/test/functional/test_table_db_mod.py
@@ -1,5 +1,5 @@
-import rethinkdb as r
-from rethinkdb import RqlRuntimeError
+from rethinkdb import r
+from rethinkdb.errors import RqlRuntimeError
 
 from mockthink import util
 from mockthink.test.common import as_db_and_table, assertEqual
@@ -115,4 +115,4 @@ class TestDbMod(MockTest):
 
     def db_list(self, conn):
         # rethinkdb is special and always present; we don't care, for these tests
-        return set(r.db_list().run(conn)) - {u'rethinkdb'}
+        return set(r.db_list().run(conn)) - {'rethinkdb'}

--- a/mockthink/test/functional/test_time.py
+++ b/mockthink/test/functional/test_time.py
@@ -1,9 +1,8 @@
 import datetime
-import rethinkdb as r
+from rethinkdb import r
 from pprint import pprint
 
-from rethinkdb import RqlCompileError, RqlDriverError
-from rethinkdb.errors import ReqlDriverCompileError
+from rethinkdb.errors import ReqlDriverCompileError, RqlCompileError, RqlDriverError
 from rethinkdb.ast import RqlTzinfo
 
 from mockthink.test.common import as_db_and_table, assertEqual, assertEqUnordered

--- a/mockthink/test/functional/test_typeof_coerce.py
+++ b/mockthink/test/functional/test_typeof_coerce.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqual
 from mockthink.test.functional.common import MockTest
 from pprint import pprint
@@ -56,7 +56,7 @@ class TestTypeOf(MockTest):
         assertEqual(expected, list(result))
 
     def test_string(self, conn):
-        expected = ['STRING']
+        expected = ['ARRAY']  # Strings are also arrays
         result = r.db('a_db').table('types').map(
             lambda doc: doc['str_attr'].type_of()
         ).run(conn)

--- a/mockthink/test/functional/test_typeof_coerce.py
+++ b/mockthink/test/functional/test_typeof_coerce.py
@@ -56,7 +56,7 @@ class TestTypeOf(MockTest):
         assertEqual(expected, list(result))
 
     def test_string(self, conn):
-        expected = ['ARRAY']  # Strings are also arrays
+        expected = ['STRING']
         result = r.db('a_db').table('types').map(
             lambda doc: doc['str_attr'].type_of()
         ).run(conn)

--- a/mockthink/test/functional/test_update_insert_delete.py
+++ b/mockthink/test/functional/test_update_insert_delete.py
@@ -1,11 +1,11 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from pprint import pprint
 
 import pytest
-import rethinkdb as r
+from rethinkdb import r
 from future.utils import text_type
-from rethinkdb import RqlRuntimeError
+from rethinkdb.errors import RqlRuntimeError
 
 from mockthink.test.common import as_db_and_table, assertEqUnordered, assertEqual
 from mockthink.test.functional.common import MockTest

--- a/mockthink/test/functional/test_without.py
+++ b/mockthink/test/functional/test_without.py
@@ -1,4 +1,4 @@
-import rethinkdb as r
+from rethinkdb import r
 from mockthink.test.common import as_db_and_table, assertEqUnordered
 from mockthink.test.functional.common import MockTest
 from pprint import pprint

--- a/mockthink/test/integration/__init__.py
+++ b/mockthink/test/integration/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 
 class MockTest(object):

--- a/mockthink/test/integration/test_things.py
+++ b/mockthink/test/integration/test_things.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
 
-import rethinkdb as r
+
+from rethinkdb import r
 
 from mockthink.test.common import assertEqUnordered, assertEqual
 from . import MockTest

--- a/mockthink/test/unit/test_joins.py
+++ b/mockthink/test/unit/test_joins.py
@@ -61,8 +61,8 @@ class TestJoins(unittest.TestCase):
         )
 
     def test_inner_join(self):
-        left = range(1, 5)
-        right = range(1, 5)
+        left = list(range(1, 5))
+        right = list(range(1, 5))
         expected = [
             {'left': 2, 'right': 1},
             {'left': 3, 'right': 1},
@@ -78,8 +78,8 @@ class TestJoins(unittest.TestCase):
         )
 
     def test_outer_join(self):
-        left = range(1, 6)
-        right = range(1, 6)
+        left = list(range(1, 6))
+        right = list(range(1, 6))
         expected = [
             {'left': 1},
             {'left': 2},

--- a/mockthink/test/unit/test_rtime.py
+++ b/mockthink/test/unit/test_rtime.py
@@ -7,7 +7,7 @@ from ... import rtime
 
 class TestRTime(unittest.TestCase):
     def test_to_date(self):
-        timezone = rethinkdb.make_timezone('00:00')
+        timezone = rethinkdb.r.make_timezone('00:00')
         dt = datetime.datetime(2014, 6, 3, 12, 5, 36, tzinfo=timezone)
         as_date = rtime.to_date(dt)
         assertEqual(2014, as_date.year)

--- a/mockthink/util.py
+++ b/mockthink/util.py
@@ -1,5 +1,3 @@
-
-
 from collections import defaultdict
 
 from future.utils import iteritems, old_div

--- a/mockthink/util.py
+++ b/mockthink/util.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from collections import defaultdict
 
@@ -9,10 +9,12 @@ def curry2(func):
     def out(x, *args):
         if len(args):
             return func(x, args[0])
+
         def out2(y):
             return func(x, y)
         return out2
     return out
+
 
 def curry3(func):
     def out(x, *args):
@@ -24,11 +26,13 @@ def curry3(func):
             return curry2(lambda a, b: func(x, a, b))(args[0])
     return out
 
+
 def extend(*dicts):
     out = {}
     for one_dict in dicts:
         out.update(one_dict)
     return out
+
 
 def clone(x):
     if isinstance(x, dict):
@@ -37,6 +41,7 @@ def clone(x):
         return clone_array(x)
     else:
         return x
+
 
 def deep_extend_pair(dict1, dict2):
     out = {}
@@ -54,11 +59,13 @@ def deep_extend_pair(dict1, dict2):
                 out[k] = clone(v)
     return out
 
+
 def deep_extend(*dicts):
     out = {}
     for one_dict in dicts:
         out = deep_extend_pair(out, one_dict)
     return out
+
 
 def cat(*lists):
     out = []
@@ -66,34 +73,42 @@ def cat(*lists):
         out.extend(one_list)
     return out
 
+
 @curry2
 def append(elem, a_list):
     return cat(a_list, [elem])
+
 
 @curry2
 def prepend(elem, a_list):
     return cat([elem], a_list)
 
+
 @curry3
 def splice_at(to_splice, index, a_list):
     return cat(a_list[0:index], to_splice, a_list[index:])
 
+
 @curry3
 def insert_at(val, index, a_list):
     return splice_at([val], index, a_list)
+
 
 @curry3
 def change_at(val, index, a_list):
     right_start = index + 1
     return cat(a_list[0:index], [val], a_list[right_start:])
 
+
 @curry2
 def extend_with(a_dict, to_extend):
     return extend(to_extend, a_dict)
 
+
 @curry2
 def map_with(fn, a_list):
     return list(map(fn, a_list))
+
 
 @curry2
 def maybe_map(fn, thing):
@@ -104,6 +119,7 @@ def maybe_map(fn, thing):
     else:
         return fn(thing)
 
+
 @curry2
 def maybe_filter(fn, thing):
     if isinstance(thing, dict):
@@ -113,8 +129,10 @@ def maybe_filter(fn, thing):
     else:
         return fn(thing)
 
+
 def is_simple(x):
     return not (isinstance(x, (list, dict)))
+
 
 @curry2
 def has_attrs(attr_list, thing):
@@ -125,9 +143,11 @@ def has_attrs(attr_list, thing):
             break
     return result
 
+
 @curry2
 def nth(n, things):
     return things[n]
+
 
 @curry2
 def getter(key, thing):
@@ -136,9 +156,11 @@ def getter(key, thing):
     else:
         return getattr(thing, key, None)
 
+
 @curry3
 def match_attr(key, val, thing):
     return getter(key, thing) == val
+
 
 @curry3
 def match_attr_multi(key, good_vals, thing):
@@ -156,6 +178,7 @@ def ensure_list(x):
         x = [x]
     return x
 
+
 @curry2
 def match_attrs(to_match, to_test):
     match = True
@@ -165,9 +188,11 @@ def match_attrs(to_match, to_test):
             break
     return match
 
+
 @curry2
 def filter_with(func, things):
-    return filter(func, things)
+    return list(filter(func, things))
+
 
 @curry2
 def find_first(pred, things):
@@ -178,6 +203,7 @@ def find_first(pred, things):
             break
     return result
 
+
 def pipeline(*funcs):
     def out(x):
         result = x
@@ -186,41 +212,52 @@ def pipeline(*funcs):
         return result
     return out
 
+
 def pluck_with(*attrs):
     def inner_pluck(thing):
-        return {k: v for k,v in iteritems(thing) if k in attrs}
+        return {k: v for k, v in iteritems(thing) if k in attrs}
     return inner_pluck
+
 
 def get_by_id(id):
     return find_first(match_attr('id', id))
 
+
 def as_obj(pairs):
     return {p[0]: p[1] for p in pairs}
 
+
 def clone_array(x):
     return [elem for elem in x]
+
 
 @curry2
 def without(bad_attrs, thing):
     return {k: v for k, v in iteritems(thing) if k not in bad_attrs}
 
+
 def obj_clone(a_dict):
     return {k: v for k, v in iteritems(a_dict)}
 
+
 def is_iterable(x):
     return hasattr(x, '__iter__')
+
 
 @curry2
 def drop(n, a_list):
     return a_list[n:]
 
+
 @curry2
 def take(n, a_list):
     return a_list[0:n]
 
+
 @curry3
 def slice_with(start, end, a_list):
     return a_list[start:end]
+
 
 @curry2
 def max_mapped(func, sequence):
@@ -231,6 +268,7 @@ def max_mapped(func, sequence):
             current = (val, elem)
     return current[1]
 
+
 @curry2
 def min_mapped(func, sequence):
     current = (func(sequence[0]), sequence[0])
@@ -240,6 +278,7 @@ def min_mapped(func, sequence):
             current = (val, elem)
     return current[1]
 
+
 @curry2
 def group_by_func(func, sequence):
     output = defaultdict(lambda: [])
@@ -247,24 +286,31 @@ def group_by_func(func, sequence):
         output[func(elem)].append(elem)
     return output
 
+
 def is_num(x):
     return isinstance(x, int) or isinstance(x, float)
 
+
 def safe_sum(nums):
     return sum(filter(is_num, nums))
+
 
 def safe_average(nums):
     actual_nums = list(filter(is_num, nums))
     return old_div(sum(actual_nums), (len(actual_nums) + 0.0))
 
+
 def safe_max(nums):
-    return max(filter(is_num, nums))
+    return max(list(filter(is_num, nums)))
+
 
 def safe_min(nums):
-    return min(filter(is_num, nums))
+    return min(list(filter(is_num, nums)))
+
 
 def array_of_string(string):
     return [char for char in string]
+
 
 def rql_str_split(string, split_on, limit=-1):
     if not split_on:
@@ -277,6 +323,7 @@ def rql_str_split(string, split_on, limit=-1):
             return string.split()
     return string.split(split_on, limit)
 
+
 def sort_by_one(sort_key, sequence, reverse=False):
     out = clone_array(sequence)
     kwargs = {
@@ -286,6 +333,7 @@ def sort_by_one(sort_key, sequence, reverse=False):
         kwargs['reverse'] = True
     out.sort(**kwargs)
     return out
+
 
 def sort_by_many(keys_and_dirs, sequence):
     # keys_and_dirs is a list of tuples and orders:
@@ -301,6 +349,7 @@ def sort_by_many(keys_and_dirs, sequence):
         result = []
         chunk = []
         current_key = None
+
         def handle_chunk():
             result.extend(sort_by_many(keys_and_dirs[1:], chunk))
         for elem in current_pass:
@@ -315,6 +364,7 @@ def sort_by_many(keys_and_dirs, sequence):
         handle_chunk()
         return result
 
+
 def indices_of_passing(pred, sequence):
     out = []
     for index in range(0, len(list(sequence))):
@@ -322,25 +372,30 @@ def indices_of_passing(pred, sequence):
             out.append(index)
     return out
 
+
 def without_indices(indices, sequence):
     indices = set(indices)
     for index in range(0, len(sequence)):
         if index not in indices:
             yield sequence[index]
 
+
 @curry2
 def eq(x, y):
     return x == y
 
+
 def sorted_iteritems(a_dict):
-    keys = a_dict.keys()
+    keys = list(a_dict.keys())
     for k in sorted(keys):
         yield k, a_dict[k]
+
 
 def sorted_list(a_list):
     a_list = clone_array(a_list)
     a_list.sort()
     return a_list
+
 
 def make_hashable(x):
     if is_simple(x):
@@ -353,9 +408,10 @@ def make_hashable(x):
             out.append((k, make_hashable(v)))
         return tuple(elem for elem in out)
 
+
 class DictableSet(set):
     def __init__(self, elems):
-        elems = map(make_hashable, elems)
+        elems = list(map(make_hashable, elems))
         super(DictableSet, self).__init__(elems)
 
     def add(self, elem):
@@ -382,4 +438,3 @@ def any_passing(pred, sequence):
             result = True
             break
     return result
-

--- a/mockthink/version.py
+++ b/mockthink/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.9.7a'
+VERSION = '0.9.8'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+rethinkdb>=2.4.8
+future==0.18.2
+python-dateutil==2.8.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 rethinkdb>=2.4.8
 future==0.18.2
 python-dateutil==2.8.1
+pytest-server-fixtures==1.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rethinkdb>=2.2.0
+rethinkdb>=2.4.8


### PR DESCRIPTION
This PR does a bunch of things:

- Some PEP8 formatting
- Drops Python 2 support
- Imports errors correctly
- Removes use of `past.builtins`
- `.args` ->`._args`
- Sets the version number to 0.9.8
- fixes `order_by(index="someindex")`
- adds `Limit` to `NORMAL_BINOPS`